### PR TITLE
Update email-template.njk

### DIFF
--- a/app/_layouts/email-template.njk
+++ b/app/_layouts/email-template.njk
@@ -22,9 +22,10 @@
         description: description
       }) }}
 
-      {% set insetText = "Replace placeholders with the correct names, dates and URLs." %}
+      {% set insetText = "Mavis automatically inserts the correct names, dates, URLs and team contact information.
+" %}
       {% if showConsentHint | default(true) %}
-        {% set insetText = insetText + " The consent URL is different for every school." %}
+        {% set insetText = insetText + " Note that the consent URL is different for every school." %}
       {% endif %}
 
       {{ nhsukInsetText({


### PR DESCRIPTION
Updated inset text at top of email templates to make it clear that Mavis automatically inserts the correct details.